### PR TITLE
docs: keep README in English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
-# VideoSubTool (strict MVC)
+# VideoSubTool
 
-PySide6-GUI zum:
-- Ordner laden und Videodateien auflisten
-- Untertitel-Streams anzeigen
-- Ausgewählten Sub exportieren (SRT wenn möglich, sonst .sup)
-- Untertitel entfernen und **Originaldatei ersetzen**
-- **Batch**-Modus mit Fortschrittsdialog
-- **Einstellungsdialog** inkl. **Sprachumschaltung (DE/EN)** und FFmpeg-Pfade
-- **FFmpeg-Finder**: Custom → System `PATH` → Bundled `resources/ffmpeg/<platform>/`
+VideoSubTool is a **PySide6** GUI on top of FFmpeg/ffprobe for managing subtitles in video files.
 
-## Dev-Setup
+## Features
+
+- Load a folder and list video files
+- Show subtitle streams
+- Export the selected subtitle (SRT when possible, otherwise SUP)
+- Remove subtitles and replace the original file
+- Batch mode with progress dialog
+- Settings dialog with language switch (DE/EN) and FFmpeg path selection
+- FFmpeg finder order: custom → system PATH → bundled `resources/ffmpeg/<platform>/`
+
+## Development / Run
 
 ```bash
 poetry install
 poetry run video-subtool
+```
+
+## FFmpeg on Windows
+
+The Windows distribution bundles FFmpeg. The included binaries are licensed separately; see `resources/LICENSES/FFmpeg` for details.
+
+## License
+
+Released under the MIT License.


### PR DESCRIPTION
## Summary
- remove German content from README
- note that Windows builds bundle FFmpeg and link to its licenses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08c7e222083328ee145f5f38e5d46