### PR TITLE
refactor(settings): remove obsolete last_dir key from configuration

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -58,6 +58,26 @@ class _DictSettings:
         except Exception:
             pass
 
+    def remove(self, key: str) -> None:
+        if key in self._data:
+            del self._data[key]
+            try:
+                self.path.write_text(json.dumps(self._data, ensure_ascii=False, indent=2), encoding="utf-8")
+            except Exception:
+                pass
+
+
+_OBSOLETE_KEYS = ("last_folder",)
+
+
+def _cleanup_obsolete(settings) -> None:
+    for key in _OBSOLETE_KEYS:
+        if hasattr(settings, "remove"):
+            try:
+                settings.remove(key)
+            except Exception:
+                pass
+
 
 def get_settings():
     """
@@ -66,8 +86,11 @@ def get_settings():
     """
     if _QSETTINGS_AVAILABLE:
         # QSettings schreibt unter Windows in die Registry, unter Linux nach ~/.config
-        return QSettings(ORG, APP)  # type: ignore
-    return _DictSettings(_CFG_FILE)
+        s = QSettings(ORG, APP)  # type: ignore
+    else:
+        s = _DictSettings(_CFG_FILE)
+    _cleanup_obsolete(s)
+    return s
 
 
 def app_data_dir() -> Path:

--- a/src/app/view/main_window.py
+++ b/src/app/view/main_window.py
@@ -157,8 +157,6 @@ class MainWindow(QMainWindow):
         # Standardordner = Verzeichnis der Anwendung
         self.default_dir = Path(sys.argv[0]).resolve().parent
         self._load_folder(self.default_dir)
-        if hasattr(self.settings, "remove"):
-            self.settings.remove("last_folder")
 
         # Startgröße (60%) & Tabellenbreiten
         self._adjust_initial_size(splitter)


### PR DESCRIPTION
## Summary
- add support for removing obsolete settings keys and cleanup on settings load
- drop `last_folder` setting and remove view-level cleanup logic

## Testing
- `pytest -q`
- `python -m py_compile src/app/settings.py src/app/view/main_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1c402c4088332b1907ee7bdb3c162