### PR TITLE
feat(ui): enable drag-and-drop for video files and remove in-window folder button

### DIFF
--- a/src/app/model/video_item.py
+++ b/src/app/model/video_item.py
@@ -6,7 +6,7 @@ from pathlib import Path
 class VideoItem:
     path: Path
 
-SUPPORTED_EXT = {".mkv", ".mp4", ".avi", ".mov", ".m4v"}
+SUPPORTED_EXT = {".mkv", ".mp4", ".avi", ".mov", ".m4v", ".ts", ".webm"}
 
 def is_video(path: Path) -> bool:
     return path.suffix.lower() in SUPPORTED_EXT


### PR DESCRIPTION
## Summary
- Remove redundant in-window "choose folder" button; folder selection now via File → Open Folder only.
- Add drag & drop support on the video list for files and directories, deduplicating and filtering by supported extensions.
- Introduce controller helper to collect valid video paths and extend supported extensions (.ts, .webm).

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_68a1c63522b88332b7127bb2d344023f