### PR TITLE
feat(ui): allow removing videos from list (delete, context menu, clear list)

### DIFF
--- a/src/app/i18n.py
+++ b/src/app/i18n.py
@@ -41,6 +41,8 @@ _STRINGS: Dict[str, Dict[str, str]] = {
         "mw.current.folder": "Aktueller Ordner",
         "mw.video.files": "Videodateien:",
         "mw.streams.in.video": "Streams im ausgewählten Video:",
+        "mw.remove.selected": "Ausgewählte entfernen",
+        "mw.clear.list": "Liste leeren",
 
         # Keep-Options (Dropdown)
         "mw.keep.forced": "nur Forced behalten",
@@ -147,6 +149,8 @@ _STRINGS: Dict[str, Dict[str, str]] = {
         "mw.current.folder": "Current folder",
         "mw.video.files": "Video files:",
         "mw.streams.in.video": "Streams in selected video:",
+        "mw.remove.selected": "Remove selected",
+        "mw.clear.list": "Clear list",
 
         # Keep-Options (Dropdown)
         "mw.keep.forced": "keep forced only",


### PR DESCRIPTION
## Summary
- Enable multi-select and Delete key handling on video list
- Add context menu and File menu actions for removing items or clearing the list
- Clear stream table when removed selection, and add German/English translations

## Testing
- `pytest`
- `python -m py_compile src/app/view/main_window.py src/app/i18n.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1d2cd96d08332b82eff71b6bd0765