### PR TITLE
feat(output): store exported subtitles and processed videos in current working folder

### DIFF
--- a/src/app/service/path_service.py
+++ b/src/app/service/path_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional
+
+
+class PathService:
+    """Resolve and store the application's current output folder."""
+
+    def __init__(self) -> None:
+        self._current: Optional[Path] = None
+
+    def set_current_folder(self, folder: Path) -> None:
+        """Set the current working folder (resolved)."""
+        self._current = Path(folder).resolve()
+
+    def get_output_folder(self) -> Path:
+        """Return the configured output folder or fall back to app directory."""
+        if self._current:
+            return self._current
+        return Path(__file__).resolve().parent
+
+
+# global singleton
+path_service = PathService()

--- a/src/app/view/workers/batch_worker.py
+++ b/src/app/view/workers/batch_worker.py
@@ -37,12 +37,12 @@ class BatchWorker(QObject):
                     self._ctrl.strip_subs(f, keep=self.keep)
                 else:
                     if self.export_rel_idx is not None:
-                        self._ctrl.export_stream(f, self.export_rel_idx, f.parent / "subs_export")
+                        self._ctrl.export_stream(f, self.export_rel_idx)
                     else:
                         # naive All-Subs-Export (0..9 versuchen)
                         for rel in range(0, 10):
                             try:
-                                self._ctrl.export_stream(f, rel, f.parent / "subs_export")
+                                self._ctrl.export_stream(f, rel)
                             except Exception:
                                 if rel == 0:
                                     break


### PR DESCRIPTION
## Summary
- centralize output directory resolution in new PathService with `get_output_folder`
- route subtitle export and subtitle stripping through current working folder
- show and use selected folder in UI, defaulting to application directory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1dc7dd22c8332bd317451786c2a3b