### PR TITLE
feat: auto-detect build icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ resources/ffmpeg/windows/ffprobe.exe
 ### Release build (optimized GUI)
 Default: fast onedir build
 ```powershell
-.\build.ps1 -Task release -Icon "resources\branding\icon.ico"
+\.\build.ps1 -Task release
 ```
 Optional: single-file build (slower startup, self-extracting EXE)
 ```powershell
-.\build.ps1 -Task release -OneFile:$true -Icon "resources\branding\icon.ico"
+\.\build.ps1 -Task release -OneFile:$true
 ```
 Artifacts appear in the `dist/` directory.
+
+The build script auto-detects `resources/branding/icon.ico` (with fallbacks). Use `-Icon <path>` to override the icon.
 
 ### Debug build (console + verbose PyInstaller logs)
 


### PR DESCRIPTION
## Summary
- auto-detect Windows icon with fallback chain
- mention automatic icon detection in build docs

## Testing
- `pytest`
- `pwsh -NoLogo -NoProfile -Command "$Task='clean'; $Icon=''; . ./build.ps1; Resolve-IconPath -IconPath $Icon"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e3f0f9b483328aa270740682d4ab